### PR TITLE
Allow users to reorder the events cards

### DIFF
--- a/planet/src/main/java/com/google/planet/data/Event.java
+++ b/planet/src/main/java/com/google/planet/data/Event.java
@@ -24,14 +24,15 @@ public final class Event {
     private final TimeRange openingHours;
     private final String listName; 
     private final String userId;
-    private final int order;
+    private final long order;
 
-    public Event(long id, String name, String address, double duration, TimeRange openingHours, int order, String listName, String userId) {
+    public Event(long id, String name, String address, double duration, TimeRange openingHours, long order, String listName, String userId) {
         this.id = id;
         this.name = name;
         this.address = address;
         this.duration = duration;
         this.openingHours = openingHours;
+        this.order = order;
         this.listName = listName;
         this.userId = userId;
     }

--- a/planet/src/main/java/com/google/planet/data/Event.java
+++ b/planet/src/main/java/com/google/planet/data/Event.java
@@ -24,8 +24,9 @@ public final class Event {
     private final TimeRange openingHours;
     private final String listName; 
     private final String userId;
+    private final int order;
 
-    public Event(long id, String name, String address, double duration, TimeRange openingHours, String listName, String userId) {
+    public Event(long id, String name, String address, double duration, TimeRange openingHours, int order, String listName, String userId) {
         this.id = id;
         this.name = name;
         this.address = address;

--- a/planet/src/main/java/com/google/planet/data/ItineraryGenerator.java
+++ b/planet/src/main/java/com/google/planet/data/ItineraryGenerator.java
@@ -20,7 +20,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 
 public final class ItineraryGenerator {
-    public List<ItineraryItem> generateItinerary(List<Event> events, Event hotel) { 
+    public List<ItineraryItem> generateItinerary(List<Event> events, Event startingPoint) { 
 
         // For the prototype, just find the shortest opening hours and 
         // schedule all events within that time range
@@ -28,8 +28,8 @@ public final class ItineraryGenerator {
         int START = events.get(0).getOpeningHours().start();
         int END = events.get(0).getOpeningHours().end();
 
-        // Add hotel as the "first" event
-        events.add(0, hotel);
+        // Add the starting point as the "first" event
+        events.add(0, startingPoint);
         int [][] travelTimeGraph = getTravelTimeGraph(events);
         List<ItineraryItem> items = scheduleItineraryInOrder(events, START, END, travelTimeGraph);
         return items;

--- a/planet/src/main/java/com/google/planet/servlets/EventServlet.java
+++ b/planet/src/main/java/com/google/planet/servlets/EventServlet.java
@@ -78,10 +78,7 @@ public class EventServlet extends HttpServlet {
         // Get the count of the current list (will need to add more filters, such as userid, listName, etc. later)
         DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
         PreparedQuery entityStats = datastore.prepare(new Query("Event"));
-        long numOfEvents = 0;
-        for (Entity entity : entityStats.asIterable()) {
-            numOfEvents += 1;
-        }
+        int numOfEvents = entityStats.countEntities();
         long order = numOfEvents + 1;
 
         String listName = "current";

--- a/planet/src/main/java/com/google/planet/servlets/ItineraryServlet.java
+++ b/planet/src/main/java/com/google/planet/servlets/ItineraryServlet.java
@@ -24,6 +24,7 @@ import com.google.appengine.api.datastore.DatastoreServiceFactory;
 import com.google.appengine.api.datastore.Entity;
 import com.google.appengine.api.datastore.PreparedQuery;
 import com.google.appengine.api.datastore.Query;
+import com.google.appengine.api.datastore.Query.SortDirection;
 import com.google.planet.data.Event;
 import java.io.IOException;
 import javax.servlet.annotation.WebServlet;
@@ -41,7 +42,7 @@ import javax.servlet.http.HttpServletResponse;
 public class ItineraryServlet extends HttpServlet {
     @Override
     public void doPost(HttpServletRequest request, HttpServletResponse response) throws IOException {
-        Query query = new Query("Event");
+        Query query = new Query("Event").addSort("order", SortDirection.ASCENDING);
         DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
         PreparedQuery results = datastore.prepare(query);
 
@@ -52,6 +53,7 @@ public class ItineraryServlet extends HttpServlet {
                                 hotelAddress, 
                                 0, 
                                 TimeRange.WHOLE_DAY, 
+                                0,
                                 "listName-none", 
                                 "userId-none");
 
@@ -64,6 +66,7 @@ public class ItineraryServlet extends HttpServlet {
             double duration = (double) entity.getProperty("duration");
             int openingTime = Math.toIntExact((long)entity.getProperty("openingTime"));
             int closingTime = Math.toIntExact((long)entity.getProperty("closingTime"));
+            long order = (long)entity.getProperty("order");
             String listName = (String) entity.getProperty("listName");
             String userId = (String) entity.getProperty("userId");
             Event event = new Event(id, 
@@ -71,6 +74,7 @@ public class ItineraryServlet extends HttpServlet {
                                     address, 
                                     duration, 
                                     TimeRange.fromStartEnd(openingTime, closingTime), 
+                                    order,
                                     listName, 
                                     userId);
             events.add(event);

--- a/planet/src/main/java/com/google/planet/servlets/ItineraryServlet.java
+++ b/planet/src/main/java/com/google/planet/servlets/ItineraryServlet.java
@@ -47,9 +47,9 @@ public class ItineraryServlet extends HttpServlet {
         PreparedQuery results = datastore.prepare(query);
 
         // Create an event called "hotel" with duration of 0
-        String hotelAddress = request.getParameter("hotel-address");
-        Event hotel = new Event( "Hotel", 
-                                hotelAddress, 
+        String startingAddress = request.getParameter("starting-address");
+        Event start = new Event( "Start", 
+                                startingAddress, 
                                 0);
 
         // Get list of events from Datastore
@@ -76,7 +76,7 @@ public class ItineraryServlet extends HttpServlet {
         }
 
         ItineraryGenerator itineraryGenerator = new ItineraryGenerator();
-        List<ItineraryItem> itinerary = itineraryGenerator.generateItinerary(events, hotel);
+        List<ItineraryItem> itinerary = itineraryGenerator.generateItinerary(events, start);
 
         response.setContentType("application/json");
         String json = new Gson().toJson(itinerary);

--- a/planet/src/main/webapp/itinerary.html
+++ b/planet/src/main/webapp/itinerary.html
@@ -28,12 +28,12 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
   </head>    
    
-  <body onload ="renderEvents(); renderHotel();">   
+  <body onload ="renderEvents(); renderStartingLocation();">   
       <div id ="content">
         <div id="events-container">
             <a class="btn-floating btn-large" onclick="openForm()"> <i class="material-icons">add</i> </a>
-            <p>Hotel/Home Address: 
-                    <input type="text" id="hotel-address" name="hotel-address" onchange="handleHotelChange()"> </input></p>
+            <p>Starting Address (Hotel/Home): 
+                    <input type="text" id="starting-address" name="starting-address" onchange="handleStartingLocationChange()"> </input></p>
             <div id="add-event" class="add-event"> 
                 <a id="close-form" onclick="closeForm()"><i class="material-icons">close</i></a></br>
                 <form action="/update-event" method="POST">   

--- a/planet/src/main/webapp/itinerary.html
+++ b/planet/src/main/webapp/itinerary.html
@@ -4,7 +4,6 @@
     <meta charset="UTF-8">
     <title>Planet</title>
     <link rel="stylesheet" href="css/itinerary.css">
-    <script src="js/itinerary.js"></script>
 
     <!--Import fonts and icons-->
     <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
@@ -17,14 +16,19 @@
     <!-- Compiled and minified JavaScript -->
     <script src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
 
-    <!-- Include the jQuery library -->   
+    <!-- Include all the jQuery libraries -->   
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.2.1/jquery.min.js"></script>
+    <script src ="https://code.jquery.com/jquery-1.10.2.js"></script>
+    <script src="https://code.jquery.com/ui/1.10.4/jquery-ui.js"></script>
+
+    <!-- Include the JS file -->   
+    <script src="js/itinerary.js"></script>
 
     <!--Let browser know website is optimized for mobile-->    
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
   </head>    
    
-  <body onload ="renderEvents(); renderHotel()">   
+  <body onload ="renderEvents(); renderHotel();">   
       <div id ="content">
         <div id="events-container">
             <a class="btn-floating btn-large" onclick="openForm()"> <i class="material-icons">add</i> </a>
@@ -50,6 +54,5 @@
         </div>
         <div id="itinerary">
         </div>
-      </div>
   </body>
 </html>

--- a/planet/src/main/webapp/js/itinerary.js
+++ b/planet/src/main/webapp/js/itinerary.js
@@ -8,7 +8,7 @@ function closeForm() {
 }
 
 function handleHotelChange() {
-    if (typeof(Storage) !== "undefined") {
+    if (typeof(Storage) !== 'undefined') {
         sessionStorage.setItem('hotel', document.getElementById('hotel-address').value);
     } else {
         alert ('Please update your browser'); 
@@ -34,7 +34,7 @@ async function renderEvents() {
 
 function createEventElement(id, name, address, duration) {
     const eventElement = document.createElement('div');
-    eventElement.setAttribute("class", "card event");
+    eventElement.setAttribute('class', 'card event');
     eventElement.innerHTML = 
         `<div class="card-content">
           <span class="card-title">` + name + `</span>
@@ -60,7 +60,7 @@ async function generateItinerary() {
         return;
     }
     const params = new URLSearchParams();
-    params.append("hotel-address", sessionStorage.getItem('hotel'));
+    params.append('hotel-address', sessionStorage.getItem('hotel'));
     const itineraryResponse = await fetch('/generate-itinerary', {method: 'POST', body: params});
     const itinerary = await itineraryResponse.json();
     createItinerary(itinerary);

--- a/planet/src/main/webapp/js/itinerary.js
+++ b/planet/src/main/webapp/js/itinerary.js
@@ -34,7 +34,7 @@ async function renderEvents() {
 
 function createEventElement(id, name, address, duration) {
     const eventElement = document.createElement('div');
-    eventElement.setAttribute("class", "card");
+    eventElement.setAttribute("class", "card event");
     eventElement.innerHTML = 
         `<div class="card-content">
           <span class="card-title">` + name + `</span>
@@ -97,3 +97,18 @@ document.addEventListener('DOMContentLoaded', function() {
 });
 
 
+// jQuery function that reorders the events
+$(function() { 
+    $( "#events" ).sortable({
+    update: function(event, ui) { 
+        reorderEvents(ui); 
+    }       
+    }); 
+}); 
+          
+function reorderEvents(ui) { 
+    $('.event').each(function (i) {
+        console.log(this.innerHTML);
+        // $(this).html(i + 2);
+    });
+} 

--- a/planet/src/main/webapp/js/itinerary.js
+++ b/planet/src/main/webapp/js/itinerary.js
@@ -108,7 +108,6 @@ $(function() {
           
 function reorderEvents(ui) { 
     $('.event').each(function (i) {
-        console.log(this.innerHTML);
-        // $(this).html(i + 2);
+        console.log('order is ' + i + ' for ' + this.innerHTML);
     });
 } 

--- a/planet/src/main/webapp/js/itinerary.js
+++ b/planet/src/main/webapp/js/itinerary.js
@@ -7,17 +7,17 @@ function closeForm() {
     document.getElementById('add-event').style.display = 'none';
 }
 
-function handleHotelChange() {
+function handleStartingLocationChange() {
     if (typeof(Storage) !== 'undefined') {
-        sessionStorage.setItem('hotel', document.getElementById('hotel-address').value);
+        sessionStorage.setItem('start', document.getElementById('starting-address').value);
     } else {
         alert ('Please update your browser'); 
     }
 }
 
-function renderHotel() {
-    if (sessionStorage.getItem('hotel')) {
-        document.getElementById('hotel-address').value = sessionStorage.getItem('hotel');
+function renderStartingLocation() {
+    if (sessionStorage.getItem('start')) {
+        document.getElementById('starting-address').value = sessionStorage.getItem('start');
     }
 }
 
@@ -55,12 +55,12 @@ async function deleteEvent(id) {
 }
 
 async function generateItinerary() {
-    if (!sessionStorage.getItem('hotel')) {
-        alert('Please input a valid hotel address');
+    if (!sessionStorage.getItem('start')) {
+        alert('Please input a valid starting address');
         return;
     }
     const params = new URLSearchParams();
-    params.append('hotel-address', sessionStorage.getItem('hotel'));
+    params.append('starting-address', sessionStorage.getItem('start'));
     const itineraryResponse = await fetch('/generate-itinerary', {method: 'POST', body: params});
     const itinerary = await itineraryResponse.json();
     createItinerary(itinerary);
@@ -95,7 +95,6 @@ document.addEventListener('DOMContentLoaded', function() {
     let elems = document.querySelectorAll('select');
     let instances = M.FormSelect.init(elems, {});
 });
-
 
 // jQuery function that reorders the events
 $(function() { 

--- a/planet/src/test/java/com/google/planet/ItineraryGeneratorTest.java
+++ b/planet/src/test/java/com/google/planet/ItineraryGeneratorTest.java
@@ -44,7 +44,7 @@ public final class ItineraryGeneratorTest {
     public void scheduleItineraryInOrder() {
         List<Event> events = new ArrayList<>();
 
-        Event hotel = new Event("Hotel", "address", 0);
+        Event hotel = new Event("Start", "address", 0);
         Event event1 = new Event(123, "Event 1", "address", 1, 
             TimeRange.fromStartEnd(TIME_0800AM, TIME_0500PM), 1, "listName", "userId");
         Event event2 = new Event(123, "Event 2", "address", 2, 
@@ -56,7 +56,7 @@ public final class ItineraryGeneratorTest {
         events.add(event3);
         List<ItineraryItem> actual = itinerary.generateItinerary(events, hotel);
         List<ItineraryItem> expected = Arrays.asList(
-            new ItineraryItem("Hotel", "address", TimeRange.fromStartEnd(480, 480)),
+            new ItineraryItem("Start", "address", TimeRange.fromStartEnd(480, 480)),
             new ItineraryItem("Event 1", "address", TimeRange.fromStartEnd(495, 555)),
             new ItineraryItem("Event 2", "address", TimeRange.fromStartEnd(570, 690)),
             new ItineraryItem("Event 3", "address", TimeRange.fromStartEnd(705, 885))
@@ -71,7 +71,7 @@ public final class ItineraryGeneratorTest {
     // empty list.
         List<Event> events = new ArrayList<>();
 
-        Event hotel = new Event("Hotel", "address", 0);
+        Event hotel = new Event("Start", "address", 0);
         Event event1 = new Event(123, "Event 1", "address", 3, 
             TimeRange.fromStartEnd(TIME_0800AM, TIME_0500PM), 1, "listName", "userId");
         Event event2 = new Event(123, "Event 2", "address", 9, 

--- a/planet/src/test/java/com/google/planet/ItineraryGeneratorTest.java
+++ b/planet/src/test/java/com/google/planet/ItineraryGeneratorTest.java
@@ -45,13 +45,13 @@ public final class ItineraryGeneratorTest {
         List<Event> events = new ArrayList<>();
 
         Event hotel = new Event(123, "Hotel", "address", 0, 
-            TimeRange.WHOLE_DAY, "listName", "userId");
+            TimeRange.WHOLE_DAY, 0, "listName", "userId");
         Event event1 = new Event(123, "Event 1", "address", 1, 
-            TimeRange.fromStartEnd(TIME_0800AM, TIME_0500PM), "listName", "userId");
+            TimeRange.fromStartEnd(TIME_0800AM, TIME_0500PM), 1, "listName", "userId");
         Event event2 = new Event(123, "Event 2", "address", 2, 
-            TimeRange.fromStartEnd(TIME_0800AM, TIME_0500PM), "listName", "userId");
+            TimeRange.fromStartEnd(TIME_0800AM, TIME_0500PM), 2, "listName", "userId");
         Event event3 = new Event(123, "Event 3", "address", 3, 
-            TimeRange.fromStartEnd(TIME_0800AM, TIME_0500PM), "listName", "userId");
+            TimeRange.fromStartEnd(TIME_0800AM, TIME_0500PM), 3, "listName", "userId");
         events.add(event1);
         events.add(event2);
         events.add(event3);
@@ -73,11 +73,11 @@ public final class ItineraryGeneratorTest {
         List<Event> events = new ArrayList<>();
 
         Event hotel = new Event(123, "Hotel", "address", 0, 
-            TimeRange.WHOLE_DAY, "listName", "userId");
+            TimeRange.WHOLE_DAY, 0, "listName", "userId");
         Event event1 = new Event(123, "Event 1", "address", 3, 
-            TimeRange.fromStartEnd(TIME_0800AM, TIME_0500PM), "listName", "userId");
+            TimeRange.fromStartEnd(TIME_0800AM, TIME_0500PM), 1, "listName", "userId");
         Event event2 = new Event(123, "Event 2", "address", 9, 
-            TimeRange.fromStartEnd(TIME_0800AM, TIME_0500PM), "listName", "userId");
+            TimeRange.fromStartEnd(TIME_0800AM, TIME_0500PM), 2, "listName", "userId");
         events.add(event1);
         events.add(event2);
         List<ItineraryItem> actual = itinerary.generateItinerary(events, hotel);


### PR DESCRIPTION
**Note**: this PR comes after PR #9 

- Use jQuery sortable plugin to enable draggable (reorder) feature
- Add property order to the event class and store it in datastore
- **TODO**: since it seems like we'll be switching to using Firebase on the client side, I didn't connect the reordering feature between client and server (firebase will do everything on the client side). Data migration from datastore to firebase will happen later today - tomorrow.
