### PR TITLE
Add responsive CSS styling to places page

### DIFF
--- a/planet/src/main/webapp/css/places.css
+++ b/planet/src/main/webapp/css/places.css
@@ -42,8 +42,8 @@ header {
     display: inline;
 }
 
-/** When screen size if greater than 700px*/
-@media screen and (min-width: 701px) {
+/** When screen size if greater than 900px*/
+@media screen and (min-width: 901px) {
     #column-map {
         height:100%;
         float: left;
@@ -56,8 +56,8 @@ header {
     }
 }
 
-/** When screen size if less than 700px*/
-@media screen and (max-width: 700px) {
+/** When screen size if less than 900px*/
+@media screen and (max-width: 900px) {
     #column-map {
         height:50%;
         float: left;
@@ -108,4 +108,12 @@ header {
 
 #place-name {
     font-weight: bold;
+}
+
+.card .card-content p {
+    font-size: 1.2vh; 
+}
+
+img {
+    width: 90%; 
 }

--- a/planet/src/main/webapp/css/places.css
+++ b/planet/src/main/webapp/css/places.css
@@ -12,16 +12,22 @@ header {
     padding: 0; 
 }
 
-#greeting {
-    margin: 0.86vh;
-    font-size: 2.6vh;
-    padding: 0.86vh;
+/** When screen size if greater than 700px, set font size to 2.6vh */
+@media screen and (min-width: 701px) {
+    #greeting {
+        margin: 0.86vh;
+        font-size: 2.6vh;
+        padding: 0.86vh;
+    }
 }
 
-#description {
-    font-family: Roboto;
-    font-size: 15px;
-    font-weight: 300;
+/** When screen size if less than 700px, set font size to 1.8vh */
+@media screen and (max-width: 700px) {
+    #greeting {
+        margin: 0.86vh;
+        font-size: 1.8vh;
+        padding: 0.86vh;
+    }
 }
 
 #infowindow-content .title {
@@ -36,9 +42,32 @@ header {
     display: inline;
 }
 
-#column {
-    height:100%;
-    float: left;
+/** When screen size if greater than 700px*/
+@media screen and (min-width: 701px) {
+    #column-map {
+        height:100%;
+        float: left;
+        width: 75%;
+    }
+    #column-places {
+        height:100%;
+        float: left;
+        width: 25%;
+    }
+}
+
+/** When screen size if less than 700px*/
+@media screen and (max-width: 700px) {
+    #column-map {
+        height:50%;
+        float: left;
+        width: 100%;
+    }
+    #column-places {
+        height:100%;
+        float: left;
+        width: 100%;
+    }
 }
 
 #results {

--- a/planet/src/main/webapp/places.html
+++ b/planet/src/main/webapp/places.html
@@ -32,13 +32,13 @@
 </header>
 
 <body>
-    <div id="column" style="width:75%;">
+    <div id="column-map">
         <input id="pac-input" class="controls " style="width:50%; background:white; margin:0.43vh; padding-left:0.57vw;"
             type="text" placeholder="Search Location">
         <div id="map"></div>
     </div>
-    <div id="column" style="width:25%;">
-        <h3 id="greeting">Find a place:</h3>
+    <div id="column-places">
+        <h3 id="greeting">Find a location:</h3>
         <div id="button-bar">
             <a id="hotel" class="btn-floating btn-large waves-effect waves-light red accent-2"><i class="material-icons">hotel</i></a>
             <a id="food" class="btn-floating btn-large waves-effect waves-light red accent-2"><i class="material-icons">local_dining</i></a>

--- a/planet/src/main/webapp/places.js
+++ b/planet/src/main/webapp/places.js
@@ -334,7 +334,7 @@ function listResults() {
         element.appendChild(div1);
     }
     // Add search keyword to header
-    document.getElementById('greeting').innerHTML = 'Find a place: ' + document.getElementById('pac-input').value;
+    document.getElementById('greeting').innerHTML = 'Find a location: ' + document.getElementById('pac-input').value;
 }
 
 function createIcon(placeID) {

--- a/planet/src/main/webapp/places.js
+++ b/planet/src/main/webapp/places.js
@@ -192,7 +192,7 @@ function callback(place, status) {
             placeDetails['Hours'] = place.opening_hours.weekday_text;
         }
         if (place.photos) {
-            placeDetails['Photo'] = place.photos[0].getUrl({maxWidth:400, maxHeight:200});
+            placeDetails['Photo'] = place.photos[0].getUrl({maxHeight:200});
         }
         if (place.url) {
             placeDetails['Website'] = place.url;


### PR DESCRIPTION
Add CSS styling to make places page responsive.

Map and places no longer share the screen width when the width is 900px. Place cards are responsive. Font sizes are responsive. 