### PR TITLE
Change add place button dynamically

### DIFF
--- a/planet/src/main/webapp/itinerary.html
+++ b/planet/src/main/webapp/itinerary.html
@@ -4,7 +4,6 @@
         <meta charset="UTF-8">
         <title>Planet</title>
         <link rel="stylesheet" href="css/itinerary.css">
-        <link rel="stylesheet" href="css/signup.css">
 
         <!--Import fonts and icons-->
         <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">

--- a/planet/src/main/webapp/js/itinerary.js
+++ b/planet/src/main/webapp/js/itinerary.js
@@ -16,6 +16,8 @@
 import TimeRange from './TimeRange.js';
 import {renderPlaces} from './placesItinerary.js';
 import {renderPlaceButtons} from './placesItinerary.js';
+import {enablePlaceButton} from './placesItinerary.js';
+import {disablePlaceButton} from './placesItinerary.js';
 // Declare global functions
 window.openAddEventForm = openAddEventForm;
 window.closeAddEventForm = closeAddEventForm;
@@ -101,7 +103,7 @@ function handleListOptionChange() {
         document.getElementById('save-events-button').style.display = 'inline-block';
     }
     renderEvents(listName);
-    renderPlaceButtons(null, false);
+    renderPlaceButtons();
 }
 
 // Add an event to the firebase realtime database
@@ -252,7 +254,7 @@ function deleteEvent(listName, ref) {
     });
 
     // Render places again since the icons might need to change
-    renderPlaceButtons(ref, true);
+    enablePlaceButton(ref);
 }
 
 async function saveEvents() {
@@ -275,7 +277,7 @@ async function saveEvents() {
     // Update the select tag options and close save events form
     renderListOptions();
     closeSaveEventsForm();
-    renderPlaceButtons(null, false);
+    renderPlaceButtons();
 }
 
 async function generateItinerary() {

--- a/planet/src/main/webapp/js/itinerary.js
+++ b/planet/src/main/webapp/js/itinerary.js
@@ -15,6 +15,7 @@
 
 import TimeRange from './TimeRange.js';
 import {renderPlaces} from './placesItinerary.js';
+import {renderPlaceButtons} from './placesItinerary.js';
 // Declare global functions
 window.openAddEventForm = openAddEventForm;
 window.closeAddEventForm = closeAddEventForm;
@@ -100,7 +101,7 @@ function handleListOptionChange() {
         document.getElementById('save-events-button').style.display = 'inline-block';
     }
     renderEvents(listName);
-    renderPlaces();
+    renderPlaceButtons(null, false);
 }
 
 // Add an event to the firebase realtime database
@@ -251,7 +252,7 @@ function deleteEvent(listName, ref) {
     });
 
     // Render places again since the icons might need to change
-    renderPlaces();
+    renderPlaceButtons(ref, true);
 }
 
 async function saveEvents() {
@@ -274,6 +275,7 @@ async function saveEvents() {
     // Update the select tag options and close save events form
     renderListOptions();
     closeSaveEventsForm();
+    renderPlaceButtons(null, false);
 }
 
 async function generateItinerary() {

--- a/planet/src/main/webapp/js/placesItinerary.js
+++ b/planet/src/main/webapp/js/placesItinerary.js
@@ -255,7 +255,6 @@ export function renderPlaceButtons(placeId, enableAdd) {
         placeListRef.once('value', (placeListSnapshot) => {
             placeListSnapshot.forEach(function(childPlace) {
                 let placeId = childPlace.key;
-                console.log(document.getElementById(placeId));
                 const noSuchEvent = document.getElementById(placeId) === null;
                 togglePlaceButton (placeId, noSuchEvent);
             });

--- a/planet/src/main/webapp/js/placesItinerary.js
+++ b/planet/src/main/webapp/js/placesItinerary.js
@@ -231,7 +231,7 @@ async function submitPlace(placeId) {
     });
 
     closeAddPlaceForm();
-    renderPlaceButtons(placeId, false);
+    disablePlaceButton(placeId);
 }
 
 function validatePlaceDuration(duration) {
@@ -246,31 +246,37 @@ function validatePlaceDuration(duration) {
     return true;
 }
 
-export function renderPlaceButtons(placeId, enableAdd) {
-    if (placeId) {
-        togglePlaceButton(placeId, enableAdd);
-    } else {
-        const userId = firebase.auth().currentUser.uid;
-        const placeListRef = database.ref('users/' + userId + '/places');
-        placeListRef.once('value', (placeListSnapshot) => {
-            placeListSnapshot.forEach(function(childPlace) {
-                let placeId = childPlace.key;
-                const noSuchEvent = document.getElementById(placeId) === null;
-                togglePlaceButton (placeId, noSuchEvent);
-            });
-        });
+export function renderPlaceButtons() {
+    if (firebase.auth().currentUser === null) {
+        return;
     }
+    const userId = firebase.auth().currentUser.uid;
+    const placeListRef = database.ref('users/' + userId + '/places');
+    placeListRef.once('value', (placeListSnapshot) => {
+        placeListSnapshot.forEach(function(childPlace) {
+            let placeId = childPlace.key;
+            const eventExists = document.getElementById(placeId) !== null;
+            if (eventExists) {
+                disablePlaceButton(placeId);
+            } else {
+                enablePlaceButton(placeId);
+            }
+        });
+    });
 } 
 
-function togglePlaceButton(placeId, enableAdd) {
+export function enablePlaceButton(placeId) {
     const placeButton = document.getElementById('place-button-' + placeId);
     if (placeButton) {
-        if (enableAdd) {
-            placeButton.setAttribute('onclick', 'openAddPlaceForm(event, "' + placeId + '")');
-            placeButton.innerHTML = `<i class="material-icons small">playlist_add</i>`;
-        } else {
-            placeButton.onclick = null;
-            placeButton.innerHTML = `<i class="material-icons small">playlist_add_check</i>`;
-        }
+        placeButton.setAttribute('onclick', 'openAddPlaceForm(event, "' + placeId + '")');
+        placeButton.innerHTML = `<i class="material-icons small">playlist_add</i>`;
+    }
+}
+
+export function disablePlaceButton(placeId) {
+    const placeButton = document.getElementById('place-button-' + placeId);
+    if (placeButton) {
+        placeButton.onclick = null;
+        placeButton.innerHTML = `<i class="material-icons small">playlist_add_check</i>`;
     }
 }

--- a/planet/src/main/webapp/js/placesItinerary.js
+++ b/planet/src/main/webapp/js/placesItinerary.js
@@ -108,6 +108,7 @@ function createPlaceElement(place) {
     // Create the add button
     const addButton = document.createElement('div');
     addButton.setAttribute('class', 'place-button');
+    addButton.setAttribute('id', 'place-button-' + place.place_id);
     
     const eventFromThisPlace = document.getElementById(place.place_id);
     if (eventFromThisPlace) {
@@ -222,7 +223,7 @@ async function submitPlace(placeId) {
     });
 
     closeAddPlaceForm();
-    renderPlaces();
+    renderPlaceButtons(placeId, false);
 }
 
 function validatePlaceDuration(duration) {
@@ -235,4 +236,34 @@ function validatePlaceDuration(duration) {
         return false;
     }
     return true;
+}
+
+export function renderPlaceButtons(placeId, enableAdd) {
+    if (placeId) {
+        togglePlaceButton(placeId, enableAdd);
+    } else {
+        const userId = firebase.auth().currentUser.uid;
+        const placeListRef = database.ref('users/' + userId + '/places');
+        placeListRef.once('value', (placeListSnapshot) => {
+            placeListSnapshot.forEach(function(childPlace) {
+                let placeId = childPlace.key;
+                console.log(document.getElementById(placeId));
+                const noSuchEvent = document.getElementById(placeId) === null;
+                togglePlaceButton (placeId, noSuchEvent);
+            });
+        });
+    }
+} 
+
+function togglePlaceButton(placeId, enableAdd) {
+    const placeButton = document.getElementById('place-button-' + placeId);
+    if (placeButton) {
+        if (enableAdd) {
+            placeButton.setAttribute('onclick', 'openAddPlaceForm(event, "' + placeId + '")');
+            placeButton.innerHTML = `<i class="material-icons small">playlist_add</i>`;
+        } else {
+            placeButton.onclick = null;
+            placeButton.innerHTML = `<i class="material-icons small">playlist_add_check</i>`;
+        }
+    }
 }

--- a/planet/src/main/webapp/js/placesItinerary.js
+++ b/planet/src/main/webapp/js/placesItinerary.js
@@ -38,8 +38,16 @@ function initAutocomplete() {
     let options = {
         types: ['geocode']
     };
-    autocompleteStart = new google.maps.places.Autocomplete(startAddress,options); 
+    autocompleteStart = new google.maps.places.Autocomplete(startAddress,options);
+    autocompleteStart.setFields(['address_component']);
+    autocompleteStart.addListener('place_changed', updateStartingAddress);
+
     autocompleteEvent = new google.maps.places.Autocomplete(eventAddress,options);
+}
+
+function updateStartingAddress() {
+    const startAddress = document.getElementById('starting-address');
+    sessionStorage.setItem('start', startAddress.value);
 }
 
 export function renderPlaces() {


### PR DESCRIPTION
This PR fixes some small issues of the itinerary page

**1.** Create function renderPlaceButtons(). 
  - **Context**: The add button of each place needs to be enabled/disabled after user adds a place/ deletes an event that used to be a place/ changes to a new list to work on. 
- Previously, the renderPlaces function is called every time these events happen, which clears the places container and fetches all the place details from the google maps api again. Therefore, a lot of redundant requests are made.
- **Fix**: The new function only changes the button, and keeps everything else the same
- if the parameter placeId is null, the function will go through every place and update their buttons, else, it will only toggle the provided place's button


**2.** Remove the line that calls the sigup.css file in itinerary.html since it's affecting the page layout


**3.** Update starting address in sessionStorage
 - **Context**: The starting address is stored in sessionStorage and is updated using an input onChange function. However, when we use the google maps autocomplete feature to fill out the address, the onChange function skips it (for example, if we type in "to" and google maps autocompletes to "toronto", the value stored in sessionStorage will still be "to"
- **Fix**: add an event listener to the autocomplete to update sessionStorage.
